### PR TITLE
Add utf8 to the list of builtin packages

### DIFF
--- a/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
@@ -49,7 +49,7 @@ sub violates {
     }
 
     my @included_packages = get_package_names_from_include_statements($doc);
-    my @builtin_packages = ( qw(main UNIVERSAL CORE CORE::GLOBAL utf8), $EMPTY );
+    my @builtin_packages = ( qw(main UNIVERSAL CORE CORE::GLOBAL utf8 overload), $EMPTY );
 
     my %all_packages =
         hashify( @declared_packages, @included_packages, @builtin_packages );

--- a/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
@@ -49,7 +49,7 @@ sub violates {
     }
 
     my @included_packages = get_package_names_from_include_statements($doc);
-    my @builtin_packages = ( qw(main UNIVERSAL CORE CORE::GLOBAL), $EMPTY );
+    my @builtin_packages = ( qw(main UNIVERSAL CORE CORE::GLOBAL utf8), $EMPTY );
 
     my %all_packages =
         hashify( @declared_packages, @included_packages, @builtin_packages );

--- a/t/Modules/RequireExplicitInclusion.run
+++ b/t/Modules/RequireExplicitInclusion.run
@@ -266,6 +266,12 @@ $__PACKAGE__::bar;
 ## cut
 utf8::is_utf8("abc");
 
+## name Allow calling functions in the overload module without including it
+## failures 0
+## cut
+overload::Overloaded("abc");
+
+
 ##############################################################################
 # Local Variables:
 #   mode: cperl

--- a/t/Modules/RequireExplicitInclusion.run
+++ b/t/Modules/RequireExplicitInclusion.run
@@ -261,6 +261,11 @@ __PACKAGE__::foo();
 &__PACKAGE__::foo();
 $__PACKAGE__::bar;
 
+## name Allow calling functions in the utf8 module without including it
+## failures 0
+## cut
+utf8::is_utf8("abc");
+
 ##############################################################################
 # Local Variables:
 #   mode: cperl


### PR DESCRIPTION
The doc for the utf8 package explicitly states that it isn't necessary to use
it to access the functions in the module.

Furthermore "use utf8" makes perl assumes that the sourcecode is written in
utf8, so using the module has side effects.
