### PR TITLE
Allow disambiguated class names

### DIFF
--- a/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
@@ -143,6 +143,11 @@ sub _extract_package_from_class_method_call {
     # which should be everything to the left of "->"
 
     my $word = shift;
+
+    # Remove trailing double colon, which is allowed and can be used for
+    # disambiguation.
+    $word =~ s/::$//;
+
     return $word;
 }
 

--- a/t/Modules/RequireExplicitInclusion.run
+++ b/t/Modules/RequireExplicitInclusion.run
@@ -261,6 +261,14 @@ __PACKAGE__::foo();
 &__PACKAGE__::foo();
 $__PACKAGE__::bar;
 
+
+## name Allow disambiguated class names
+## failures 0
+## cut
+
+use Foo::Bar;
+Foo::Bar::->test();
+
 ##############################################################################
 # Local Variables:
 #   mode: cperl


### PR DESCRIPTION
Remove trailing double colons on method call class names, as this is perfectly
valid perl code, and can be used to disambiguate class names.

This fixes issue Perl-Critic/Perl-Critic-StricterSubs#3
