### PR TITLE
extract package from subroutine call

### DIFF
--- a/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
+++ b/lib/Perl/Critic/Policy/Modules/RequireExplicitInclusion.pm
@@ -155,7 +155,7 @@ sub _extract_package_from_subroutine_call {
     # to (but not including) the last "::".
 
     my $word = shift;
-    if ($word->content() =~ m/\A ( .* ) :: [^:]+ \z/xms) {
+    if ($word->content() =~ m/\A ( .* ) :: [^:]* \z/xms) {
         return $1;
     }
 

--- a/t/20_policies.t
+++ b/t/20_policies.t
@@ -3,6 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::NoWarnings;
 use English qw(-no_match_vars);
 
 # common P::C testing tools
@@ -31,7 +32,7 @@ for my $s (values %$subtests) {
 }
 my $npolicies = scalar keys %$subtests; # one can() test per policy
 
-plan tests => $nsubtests + $npolicies;
+plan tests => $nsubtests + $npolicies + 1; # add 1 for warnings test
 
 for my $policy ( sort keys %$subtests ) {
     can_ok( "Perl::Critic::Policy::$policy", 'violates' );

--- a/t/Modules/RequireExplicitInclusion.run
+++ b/t/Modules/RequireExplicitInclusion.run
@@ -7,11 +7,12 @@
 
 ## ----- Perl::Critic::Policy::Modules::RequireExplicitInclusion [ 2.0 ] -----
 ## name Qualified function from package that *is not* explicitly included
-## failures 6
+## failures 7
 ## cut
 
 package main;
 
+Foo::;                 #Disambiguated class name
 Foo::foo;              #No parens
 Foo::foo();            #No args
 Foo::foo( 'quux' );    #With args


### PR DESCRIPTION
- Allow for class names with trailing suffix in _extract_package_from_subroutine_call()
- Test that a class name with a trailing '::' does not generate a warning
